### PR TITLE
Allow passing tag options to helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
 
 [[package]]
 name = "isorun"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "deno_console",
  "deno_core",

--- a/app/helpers/isorun/app_helper.rb
+++ b/app/helpers/isorun/app_helper.rb
@@ -14,10 +14,13 @@ module Isorun
     #   </body>
     #   </html>
     #
+    # @see https://api.rubyonrails.org/v5.1/classes/ActionView/Helpers/TagHelper.html#method-i-tag
     # @param id [String] An ID representing both, the asset bundle, and by
     #   convention, the target node (e.g. `<div id="my_app">`)
+    # @param [Hash] options All valid tag options can also passed as options
+    #   to this method
     # @return [String]
-    def isorun_app(id) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def isorun_app(id, options = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       ActiveSupport::Notifications.instrument "start.render.isorun", { ts: Time.current }
 
       module_path = Isorun.config.module_resolver.call(id)
@@ -43,7 +46,10 @@ module Isorun
       end
 
       html = if ssr_html.present?
-               tag.div id: id do
+               options ||= {}
+               options[:id] = id
+
+               tag.div(**options) do
                  ssr_html.html_safe # rubocop:disable Rails/OutputSafety
                end
              else

--- a/app/helpers/isorun/vite_app_helper.rb
+++ b/app/helpers/isorun/vite_app_helper.rb
@@ -15,10 +15,13 @@ module Isorun
     #   </body>
     #   </html>
     #
-    # @param id [String] An ID representing both, the asset bundle, and by
+    # @see https://api.rubyonrails.org/v5.1/classes/ActionView/Helpers/TagHelper.html#method-i-tag
+    # @param [String] id An ID representing both, the asset bundle, and by
     #   convention, the target node (e.g. `<div id="my_app">`)
+    # @param [Hash] options All valid tag options can also passed as options
+    #   to this method
     # @return [String]
-    def isorun_vite_app(id) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def isorun_vite_app(id, options = nil)
       ActiveSupport::Notifications.instrument "start.render.isorun", { ts: Time.current }
 
       # if id has a file extension, we extract the extension and reduce the ID
@@ -49,7 +52,10 @@ module Isorun
       end
 
       html = if ssr_html.present?
-               tag.div id: id do
+               options ||= {}
+               options[:id] = id
+
+               tag.div(**options) do
                  ssr_html.html_safe # rubocop:disable Rails/OutputSafety
                end
              else

--- a/ext/isorun/Cargo.toml
+++ b/ext/isorun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "isorun"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Hannes Moser <box@hannesmoser.at>"]
 homepage = "https://github.com/eliias/isorun"

--- a/lib/isorun/version.rb
+++ b/lib/isorun/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Isorun
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end


### PR DESCRIPTION
Allows passing all valid tag options. e.g. `class`, `id`, …